### PR TITLE
Support -dev as suffix

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -50,7 +50,10 @@ final class Package
 
         $reference = $this->data->findString('source.reference');
 
-        if (\strlen($reference) >= self::HASH_LENGTH && \str_starts_with($version, 'dev-')) {
+        if (
+            \strlen($reference) >= self::HASH_LENGTH
+            && (\str_starts_with($version, 'dev-') || (\str_ends_with($version, '-dev')))
+        ) {
             $version = \substr($reference, 0, self::HASH_LENGTH);
             if ($prettyPrint) {
                 $version = "{$this->data->getString('version')}@{$version}";

--- a/tests/AbstractComposerDiffTest.php
+++ b/tests/AbstractComposerDiffTest.php
@@ -217,6 +217,26 @@ abstract class AbstractComposerDiffTest extends PHPUnit
                 __DIR__ . '/fixtures/testComparingChangedPackage/composer-lock-to.json',
             )),
         );
+
+        isSame(
+            [
+                'require' => [
+                    [
+                        'name'         => 'vendor-1/package-1',
+                        'url'          => 'https://gitlab.com/vendor-1/package-1',
+                        'version_from' => '1.x-dev@bbc0fba',
+                        'version_to'   => '1.x-dev@4121ea4',
+                        'mode'         => 'Changed',
+                        'compare'      => 'https://gitlab.com/vendor-1/package-1/compare/bbc0fba...4121ea4',
+                    ],
+                ],
+                'require-dev' => [],
+            ],
+            $this->toArray(Comparator::compare(
+                __DIR__ . '/fixtures/testComparingChangedPackageSuffix/composer-lock-from.json',
+                __DIR__ . '/fixtures/testComparingChangedPackageSuffix/composer-lock-to.json',
+            )),
+        );
     }
 
     public function testComparingComplex(): void

--- a/tests/fixtures/testComparingChangedPackageSuffix/composer-lock-from.json
+++ b/tests/fixtures/testComparingChangedPackageSuffix/composer-lock-from.json
@@ -1,0 +1,13 @@
+{
+    "packages" : [
+        {
+            "name"    : "vendor-1/package-1",
+            "version" : "1.x-dev",
+            "source"  : {
+                "type"      : "git",
+                "url"       : "git@gitlab.com:vendor-1/package-1.git",
+                "reference" : "bbc0fba999014432ff2f928045a3e4121ea4a825"
+            }
+        }
+    ]
+}

--- a/tests/fixtures/testComparingChangedPackageSuffix/composer-lock-to.json
+++ b/tests/fixtures/testComparingChangedPackageSuffix/composer-lock-to.json
@@ -1,0 +1,13 @@
+{
+    "packages" : [
+        {
+            "name"    : "vendor-1/package-1",
+            "version" : "1.x-dev",
+            "source"  : {
+                "type"      : "git",
+                "url"       : "git@gitlab.com:vendor-1/package-1.git",
+                "reference" : "4121ea4a825bbc0fba999014432ff2f928045a3e"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
It is supported to have `-dev` as a suffix in composer, which pretty much behaves same as a prefix (`dev-`) - see https://getcomposer.org/doc/articles/versions.md#branches.. however if you do do this this package doesn't pick up this as a diff, so I've updated the if to make it supported.